### PR TITLE
modules: openthread: platform: Added setting default tx power

### DIFF
--- a/modules/openthread/Kconfig.thread
+++ b/modules/openthread/Kconfig.thread
@@ -167,3 +167,11 @@ config OPENTHREAD_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
 	bool "Stay awake between packet fragments"
 	help
 	  This optimization is done at the expense of power consumption on SED/SSED devices.
+
+config OPENTHREAD_DEFAULT_TX_POWER
+	int "Openthread default tx power in dBm"
+	range -40 20 if NRF_802154_RADIO_DRIVER
+	default 0
+	help
+	  Set the default TX output power [dBm] in radio driver for openthread purpose. 
+

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -83,7 +83,8 @@ static const struct device *const radio_dev =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_ieee802154));
 static struct ieee802154_radio_api *radio_api;
 
-static int8_t tx_power;
+/* Get the default tx output power from Kconfig */
+static int8_t tx_power = CONFIG_OPENTHREAD_DEFAULT_TX_POWER;
 static uint16_t channel;
 static bool promiscuous;
 


### PR DESCRIPTION
There were some requests from users for adding the possibility of setting default openthread tx output power using kConfig. It is possible by adding the CONFIG_OPENTHREAD_DEFAULT_TX_POWER kConfig and assigning it to the tx_power variable in the radio.c file in the Openthread module.

Added the possibility to set default openthread power using kConfig.

Signed-off-by: Arkadiusz Balys <arkadiusz.balys@nordicsemi.no>